### PR TITLE
Add esp32 camera dir

### DIFF
--- a/src/micropython.cmake
+++ b/src/micropython.cmake
@@ -8,15 +8,20 @@ target_sources(usermod_mp_camera INTERFACE
     ${CMAKE_CURRENT_LIST_DIR}/modcamera_api.c
 )
 
-if(EXISTS "${IDF_PATH}/components/esp32-camera")
+if(NOT ESP32_CAMERA_DIR)
+    set(ESP32_CAMERA_DIR "${IDF_PATH}/components/esp32-camera")
+endif()
+
+message("Camera Dir: ${ESP32_CAMERA_DIR}")
+
+if(EXISTS "${ESP32_CAMERA_DIR}")
     target_include_directories(usermod_mp_camera INTERFACE
         ${CMAKE_CURRENT_LIST_DIR}
-        ${IDF_PATH}/components/esp32-camera/driver/include
-        ${IDF_PATH}/components/esp32-camera/driver/private_include
-        ${IDF_PATH}/components/esp32-camera/conversions/include
-        ${IDF_PATH}/components/esp32-camera/conversions/private_include
-        ${IDF_PATH}/components/esp32-camera/sensors/private_include
-    )
+        ${ESP32_CAMERA_DIR}/driver/include
+        ${ESP32_CAMERA_DIR}/driver/private_include
+        ${ESP32_CAMERA_DIR}/conversions/include
+        ${ESP32_CAMERA_DIR}/conversions/private_include
+        ${ESP32_CAMERA_DIR}/sensors/private_include
 else()
     target_include_directories(usermod_mp_camera INTERFACE
         ${CMAKE_CURRENT_LIST_DIR})

--- a/src/micropython.cmake
+++ b/src/micropython.cmake
@@ -22,6 +22,7 @@ if(EXISTS "${ESP32_CAMERA_DIR}")
         ${ESP32_CAMERA_DIR}/conversions/include
         ${ESP32_CAMERA_DIR}/conversions/private_include
         ${ESP32_CAMERA_DIR}/sensors/private_include
+    )
 else()
     target_include_directories(usermod_mp_camera INTERFACE
         ${CMAKE_CURRENT_LIST_DIR})


### PR DESCRIPTION
Hi, I am including your project in my project as a submodule, see https://github.com/ROSMicroPy/ROSMicroPy
I ran into a problem with include directories, so I made that minor change that allows you to override the directories where the includes exist for the esp32-camera component.  It should function the same as you have it if you do not provide an override.  Please let me know if you have any questions.

-John